### PR TITLE
Fixes for TestConfig and TestAwsSecret

### DIFF
--- a/dcplib/aws_secret.py
+++ b/dcplib/aws_secret.py
@@ -1,8 +1,12 @@
+from time import sleep
+
 import boto3
 from botocore.errorfactory import ClientError
 
 
 class AwsSecret:
+
+    AWS_SECRETS_MGR_SETTLE_TIME_SEC = 2
 
     """
     Wrapper for AWS secrets.
@@ -64,6 +68,7 @@ class AwsSecret:
             raise RuntimeError("No such secret: {}".format(self.name))
         if not self.is_deleted:
             self.secrets_mgr.delete_secret(SecretId=self.arn)
+            sleep(self.AWS_SECRETS_MGR_SETTLE_TIME_SEC)  # eventual consistency
             self._load()
 
     def _load(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,7 @@
 import os
+import uuid
+
+import boto3
 
 
 class EnvironmentSetup:
@@ -34,3 +37,46 @@ class EnvironmentSetup:
 
 def fixture_file_path(filename):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), 'fixtures', filename))
+
+
+class ExistingAwsSecretTestFixture:
+
+    """
+    A test fixture to manage an AWS Secrets Manager secret.
+    It is a context manager that will instantiate and tear down the secret around your code.
+    Use it with:
+
+        with ExistingAwsSecretTestFixture(secret_name="foo", secret_value="bar") as secret:
+            print("My name is {secret.name}")
+            # test something
+
+    If you leave the secret_name blank, a unique name will be generated for you.
+    """
+
+    SECRET_ID_TEMPLATE = 'dcplib/test/test_secret/{}'
+    EXISTING_SECRET_DEFAULT_VALUE = '{"top":"secret"}'
+
+    def __init__(self, secret_name=None, secret_value=None):
+        self.secrets_mgr = boto3.client("secretsmanager")
+        self.name = secret_name or self.SECRET_ID_TEMPLATE.format(uuid.uuid4())
+        self._value = secret_value or self.EXISTING_SECRET_DEFAULT_VALUE
+        self._secret = None
+
+    def __enter__(self):
+        self._secret = self.secrets_mgr.create_secret(Name=self.name,
+                                                      SecretString=self._value)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.delete()
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def arn(self):
+        return self._secret['ARN']
+
+    def delete(self):
+        self.secrets_mgr.delete_secret(SecretId=self.arn, ForceDeleteWithoutRecovery=True)

--- a/tests/test_aws_secret.py
+++ b/tests/test_aws_secret.py
@@ -1,6 +1,5 @@
 import sys
 import unittest
-import uuid
 
 from mock import patch
 
@@ -8,42 +7,13 @@ import boto3
 
 from dcplib.aws_secret import AwsSecret
 
+from . import ExistingAwsSecretTestFixture
+
 
 @unittest.skipIf(sys.version_info < (3, 6), "Only testing under Python 3.6+")
 class TestAwsSecret(unittest.TestCase):
 
     UNKNOWN_SECRET = 'dcplib/test/secret_that_does_not_exist'  # Don't ever create this
-
-    class ExistingSecretTestFixture:
-
-        SECRET_ID_TEMPLATE = 'dcplib/test/test_secret/{}'
-        EXISTING_SECRET_DEFAULT_VALUE = '{"top":"secret"}'
-
-        def __init__(self):
-            self.secrets_mgr = boto3.client("secretsmanager")
-            self.secret_id = self.SECRET_ID_TEMPLATE.format(uuid.uuid4())
-            self._secret = None
-            self._value = None
-
-        def __enter__(self, secret_value=None):
-            self._value = secret_value or self.EXISTING_SECRET_DEFAULT_VALUE
-            self._secret = self.secrets_mgr.create_secret(Name=self.secret_id,
-                                                          SecretString=self._value)
-            return self
-
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            self.delete()
-
-        @property
-        def value(self):
-            return self._value
-
-        @property
-        def arn(self):
-            return self._secret['ARN']
-
-        def delete(self):
-            self.secrets_mgr.delete_secret(SecretId=self.arn, ForceDeleteWithoutRecovery=True)
 
     @classmethod
     def setUpClass(cls):
@@ -62,28 +32,28 @@ class TestAwsSecret(unittest.TestCase):
         self.assertEqual(secret.secret_metadata, None)
 
     def test_init_of_existing_secret_retrieves_secret_metadata(self):
-        with self.ExistingSecretTestFixture() as existing_secret:
-            secret = AwsSecret(name=existing_secret.secret_id)
+        with ExistingAwsSecretTestFixture() as existing_secret:
+            secret = AwsSecret(name=existing_secret.name)
             self.assertIsNotNone(secret.secret_metadata)
 
     # value
 
     def test_value_of_unknown_secret_raises_exception(self):
-        with self.ExistingSecretTestFixture():
+        with ExistingAwsSecretTestFixture():
             secret = AwsSecret(name=self.UNKNOWN_SECRET)
             with self.assertRaisesRegex(RuntimeError, 'No such'):
                 secret.value  # noqa
 
     def test_value_of_existing_deleted_secret_raises_exception(self):
-        with self.ExistingSecretTestFixture() as existing_secret:
-            secret = AwsSecret(name=existing_secret.secret_id)
+        with ExistingAwsSecretTestFixture() as existing_secret:
+            secret = AwsSecret(name=existing_secret.name)
             secret.delete()
             with self.assertRaisesRegex(RuntimeError, 'deleted'):
                 x = secret.value  # noqa
 
     def test_value_of_existing_secret_returns_value(self):
-        with self.ExistingSecretTestFixture() as existing_secret:
-            secret = AwsSecret(name=existing_secret.secret_id)
+        with ExistingAwsSecretTestFixture() as existing_secret:
+            secret = AwsSecret(name=existing_secret.name)
             self.assertEqual(secret.value, existing_secret.value)
 
     # update
@@ -94,8 +64,8 @@ class TestAwsSecret(unittest.TestCase):
             secret.delete()
 
     def test_update_of_existing_secret_updates_secret(self):
-        with self.ExistingSecretTestFixture() as existing_secret:
-            secret = AwsSecret(name=existing_secret.secret_id)
+        with ExistingAwsSecretTestFixture() as existing_secret:
+            secret = AwsSecret(name=existing_secret.name)
             secret.update(value='{"foo":"bar"}')
             self.assertEqual(self.secrets_mgr.get_secret_value(SecretId=existing_secret.arn)['SecretString'],
                              '{"foo":"bar"}')
@@ -103,8 +73,8 @@ class TestAwsSecret(unittest.TestCase):
     # delete
 
     def test_delete_of_existing_secret_deletes_secret(self):
-        with self.ExistingSecretTestFixture() as existing_secret:
-            secret = AwsSecret(name=existing_secret.secret_id)
+        with ExistingAwsSecretTestFixture() as existing_secret:
+            secret = AwsSecret(name=existing_secret.name)
             secret.delete()
             secret = self.secrets_mgr.describe_secret(SecretId=existing_secret.arn)
             self.assertIn('DeletedDate', secret)

--- a/tests/test_aws_secret.py
+++ b/tests/test_aws_secret.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 from mock import patch
+from time import sleep
 
 import boto3
 
@@ -67,6 +68,7 @@ class TestAwsSecret(unittest.TestCase):
         with ExistingAwsSecretTestFixture() as existing_secret:
             secret = AwsSecret(name=existing_secret.name)
             secret.update(value='{"foo":"bar"}')
+            sleep(AwsSecret.AWS_SECRETS_MGR_SETTLE_TIME_SEC)
             self.assertEqual(self.secrets_mgr.get_secret_value(SecretId=existing_secret.arn)['SecretString'],
                              '{"foo":"bar"}')
 


### PR DESCRIPTION
To better work around AWS Secrets Manager's slow eventual consistency delivery.